### PR TITLE
Add programme supabase persistence

### DIFF
--- a/apprend-final/README.md
+++ b/apprend-final/README.md
@@ -39,6 +39,11 @@ src/
 
 ## Available Scripts
 
+
+### Supabase Schema
+The project expects two tables: `user_programmes` and `programme_entries`.
+Run the SQL in `supabase/schema.sql` on your Supabase instance to create them.
+
 - `npm run dev` – start the dev server with Turbopack
 - `npm run build` – create an optimized production build
 - `npm start` – run the built app

--- a/apprend-final/src/app/programme/components/SaveButton.tsx
+++ b/apprend-final/src/app/programme/components/SaveButton.tsx
@@ -1,0 +1,31 @@
+'use client';
+import React, { useState } from 'react';
+import { ProgrammeData } from '@/lib/types/programme';
+import { programmeSupabaseService } from '@/lib/programmeSupabaseService';
+
+interface SaveButtonProps {
+  programme: ProgrammeData;
+}
+
+export default function SaveButton({ programme }: SaveButtonProps) {
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  const handleClick = async () => {
+    setSaving(true);
+    await programmeSupabaseService.saveProgramme(programme);
+    setSaving(false);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={saving}
+      className="px-4 py-2 bg-purple-500 text-white rounded-full disabled:opacity-50"
+    >
+      {saving ? 'Enregistrement…' : saved ? 'Enregistré !' : 'Sauvegarder'}
+    </button>
+  );
+}

--- a/apprend-final/src/app/programme/components/SubPartTemplate.tsx
+++ b/apprend-final/src/app/programme/components/SubPartTemplate.tsx
@@ -1,0 +1,42 @@
+'use client';
+import React, { useState } from 'react';
+import { SubPart } from '@/lib/types/programme';
+import { programmeSupabaseService } from '@/lib/programmeSupabaseService';
+
+interface SubPartTemplateProps {
+  userId: string;
+  subPart: SubPart;
+  onSaved?: () => void;
+}
+
+export default function SubPartTemplate({ userId, subPart, onSaved }: SubPartTemplateProps) {
+  const [value, setValue] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const handleAdd = async () => {
+    if (!value.trim()) return;
+    setSaving(true);
+    await programmeSupabaseService.addField(userId, subPart.id, value);
+    setValue('');
+    setSaving(false);
+    onSaved?.();
+  };
+
+  return (
+    <div className="space-y-4">
+      <textarea
+        className="w-full border rounded p-2"
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        placeholder={subPart.placeholder}
+      />
+      <button
+        onClick={handleAdd}
+        disabled={saving}
+        className="px-4 py-2 bg-blue-500 text-white rounded disabled:opacity-50"
+      >
+        {saving ? 'Ajout…' : 'Ajouter'}
+      </button>
+    </div>
+  );
+}

--- a/apprend-final/src/lib/programmeSupabaseService.ts
+++ b/apprend-final/src/lib/programmeSupabaseService.ts
@@ -1,0 +1,85 @@
+import { supabase } from './supabase';
+import { ProgrammeData, SubPart, SUBPARTS_CONFIG, SubPartField } from './types/programme';
+
+class ProgrammeSupabaseService {
+  async getProgramme(userId: string): Promise<ProgrammeData | null> {
+    const { data: programmeRow } = await supabase
+      .from('user_programmes')
+      .select('*')
+      .eq('user_id', userId)
+      .single();
+
+    if (!programmeRow) return null;
+
+    const { data: entries } = await supabase
+      .from('programme_entries')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at');
+
+    const subParts: SubPart[] = SUBPARTS_CONFIG.map(config => ({
+      ...config,
+      fields: [],
+      completed: false,
+      progress: 0
+    }));
+
+    entries?.forEach(entry => {
+      const part = subParts.find(p => p.id === entry.subpart_id);
+      if (part) {
+        const field: SubPartField = {
+          id: entry.id,
+          value: entry.value,
+          createdAt: new Date(entry.created_at)
+        };
+        part.fields.push(field);
+      }
+    });
+
+    const programme: ProgrammeData = {
+      userId,
+      subParts,
+      currentSubPart: programmeRow.current_subpart,
+      overallProgress: programmeRow.overall_progress,
+      lastUpdated: new Date(programmeRow.last_updated),
+      completedAt: programmeRow.completed_at ? new Date(programmeRow.completed_at) : undefined
+    };
+
+    subParts.forEach(part => {
+      const min = part.minFields || 1;
+      part.progress = Math.min(100, Math.round((part.fields.length / min) * 100));
+      part.completed = part.progress >= 100;
+    });
+    const total = subParts.reduce((acc, p) => acc + p.progress, 0);
+    programme.overallProgress = Math.round(total / subParts.length);
+
+    return programme;
+  }
+
+  async saveProgramme(programme: ProgrammeData): Promise<void> {
+    await supabase
+      .from('user_programmes')
+      .upsert({
+        user_id: programme.userId,
+        overall_progress: programme.overallProgress,
+        current_subpart: programme.currentSubPart,
+        last_updated: new Date().toISOString(),
+        completed_at: programme.completedAt ? programme.completedAt.toISOString() : null
+      });
+  }
+
+  async addField(userId: string, subPartId: number, value: string): Promise<void> {
+    await supabase
+      .from('programme_entries')
+      .insert({ user_id: userId, subpart_id: subPartId, value });
+  }
+
+  async removeField(fieldId: string): Promise<void> {
+    await supabase
+      .from('programme_entries')
+      .delete()
+      .eq('id', fieldId);
+  }
+}
+
+export const programmeSupabaseService = new ProgrammeSupabaseService();

--- a/apprend-final/supabase/schema.sql
+++ b/apprend-final/supabase/schema.sql
@@ -1,0 +1,16 @@
+CREATE TABLE user_programmes (
+  id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  current_subpart integer NOT NULL DEFAULT 0,
+  overall_progress integer NOT NULL DEFAULT 0,
+  last_updated timestamp with time zone NOT NULL DEFAULT now(),
+  completed_at timestamp with time zone
+);
+
+CREATE TABLE programme_entries (
+  id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  subpart_id integer NOT NULL,
+  value text NOT NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- define new `user_programmes` and `programme_entries` tables
- implement `programmeSupabaseService` for CRUD with Supabase
- create reusable components `SaveButton` and `SubPartTemplate`
- document the required tables in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aee049df8832ab5683f36427df91d