### PR TITLE
Store profession and country labels

### DIFF
--- a/apprend-final/src/app/personalisation/page.tsx
+++ b/apprend-final/src/app/personalisation/page.tsx
@@ -1,8 +1,13 @@
 'use client';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import WelcomeStep from '../../components/personalisation/WelcomeStep';
 import PersonalInfoStep from '../../components/personalisation/PersonalInfoStep';
 import SuccessStep from '../../components/personalisation/SuccessStep';
+import { UserProfileService } from '../../lib/userProfileService';
+import {
+  getProfessionValueFromLabel,
+  getCountryValueFromLabel,
+} from '../../lib/dataMappings';
 
 export interface UserData {
   name: string;
@@ -20,6 +25,24 @@ export default function PersonalisationPage() {
     birthYear: new Date().getFullYear(),
     profession: ''
   });
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      const { data } = await UserProfileService.getUserProfile();
+      if (data) {
+        setUserData({
+          name: data.name || '',
+          birthYear: data.birth_year || new Date().getFullYear(),
+          profession: getProfessionValueFromLabel(data.profession || ''),
+          gender: data.gender || undefined,
+          phone: data.phone || undefined,
+          country: getCountryValueFromLabel(data.country || '') || undefined,
+        });
+      }
+    };
+
+    fetchProfile();
+  }, []);
 
   const handleNext = () => {
     setCurrentStep(prev => prev + 1);

--- a/apprend-final/src/components/personalisation/SuccessStep.tsx
+++ b/apprend-final/src/components/personalisation/SuccessStep.tsx
@@ -4,6 +4,10 @@ import { UserData } from '../../app/personalisation/page';
 import { UserProfileService } from '../../lib/userProfileService';
 import { programmeSupabaseService } from '../../lib/programmeSupabaseService';
 import { supabase } from '../../lib/supabase';
+import {
+  getProfessionLabelFromValue,
+  getCountryLabelFromValue,
+} from '../../lib/dataMappings';
 
 interface SuccessStepProps {
   userData: UserData;
@@ -172,10 +176,12 @@ export default function SuccessStep({ userData, onNext, onBack }: SuccessStepPro
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-gray-700">
             <div><strong>Nom :</strong> {userData.name}</div>
             <div><strong>Année de naissance :</strong> {userData.birthYear}</div>
-            <div><strong>Profession :</strong> {userData.profession}</div>
+            <div><strong>Profession :</strong> {getProfessionLabelFromValue(userData.profession)}</div>
             {userData.gender && <div><strong>Genre :</strong> {userData.gender}</div>}
             {userData.phone && <div><strong>Téléphone :</strong> {userData.phone}</div>}
-            {userData.country && <div><strong>Pays :</strong> {userData.country}</div>}
+            {userData.country && (
+              <div><strong>Pays :</strong> {getCountryLabelFromValue(userData.country)}</div>
+            )}
           </div>
         </div>
 

--- a/apprend-final/src/lib/dataMappings.ts
+++ b/apprend-final/src/lib/dataMappings.ts
@@ -1,0 +1,21 @@
+import { CSP_OPTIONS, COUNTRY_OPTIONS } from './constants';
+
+export const getProfessionLabelFromValue = (value: string): string => {
+  const option = CSP_OPTIONS.find(o => o.value === value);
+  return option?.label || value;
+};
+
+export const getProfessionValueFromLabel = (label: string): string => {
+  const option = CSP_OPTIONS.find(o => o.label === label);
+  return option?.value || '';
+};
+
+export const getCountryLabelFromValue = (value: string): string => {
+  const option = COUNTRY_OPTIONS.find(o => o.value === value);
+  return option?.label || value;
+};
+
+export const getCountryValueFromLabel = (label: string): string => {
+  const option = COUNTRY_OPTIONS.find(o => o.label === label);
+  return option?.value || '';
+};

--- a/apprend-final/src/lib/userProfileService.ts
+++ b/apprend-final/src/lib/userProfileService.ts
@@ -1,5 +1,9 @@
 import { supabase } from './supabase';
 import { UserData } from '../app/personalisation/page';
+import {
+  getProfessionLabelFromValue,
+  getCountryLabelFromValue,
+} from './dataMappings';
 
 export interface UserProfile extends UserData {
   id?: string;
@@ -31,10 +35,10 @@ export class UserProfileService {
         user_id: user.id,
         name: userData.name,
         birth_year: userData.birthYear,
-        profession: userData.profession,
+        profession: getProfessionLabelFromValue(userData.profession),
         gender: userData.gender || null,
         phone: userData.phone || null,
-        country: userData.country || null,
+        country: userData.country ? getCountryLabelFromValue(userData.country) : null,
         updated_at: new Date().toISOString()
       };
 


### PR DESCRIPTION
## Summary
- add utility to convert profession/country values to labels and back
- store profession and country labels when saving profile
- fetch saved profile and prefill personalisation form
- display profession and country labels in personalisation summary

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876cec613d0832a8781ae9698fa1e38