### PR TITLE
Refactor renaissance modules

### DIFF
--- a/src/app/renaissance/components/AxeSelectionCard.tsx
+++ b/src/app/renaissance/components/AxeSelectionCard.tsx
@@ -4,16 +4,7 @@
 'use client';
 
 import React from 'react';
-
-export interface RenaissanceAxe {
-  id: string;
-  name: string;
-  icon: string;
-  description: string;
-  sortOrder: number;
-  isActive: boolean;
-  isCustomizable: boolean;
-}
+import type { RenaissanceAxe } from '@/lib/types/renaissance';
 
 interface AxeSelectionCardProps {
   axe: RenaissanceAxe;


### PR DESCRIPTION
## Summary
- use shared types and services for Renaissance pages
- centralize axe selection component logic
- import FlashPhraseGame and comparison utilities

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68799eef8368832a98f405231a5b508e